### PR TITLE
allow turbine decompos to be extended with custom decomps instead of just the ops

### DIFF
--- a/iree/turbine/aot/decompositions.py
+++ b/iree/turbine/aot/decompositions.py
@@ -31,11 +31,16 @@ def extend_aot_decompositions(
     *,
     from_current: bool = True,
     add_ops: Optional[DecompositionOpsList] = None,
-    remove_ops: Optional[DecompositionOpsList] = None
+    remove_ops: Optional[DecompositionOpsList] = None,
+    add_decomps: Optional[DecompositionTable] = None
 ):
     """Context manager which extends the list of decompositions used for AOT."""
     return _extend_context_manager(
-        "aot", from_current=from_current, add_ops=add_ops, remove_ops=remove_ops
+        "aot",
+        from_current=from_current,
+        add_ops=add_ops,
+        remove_ops=remove_ops,
+        add_decomps=add_decomps,
     )
 
 

--- a/iree/turbine/dynamo/decompositions.py
+++ b/iree/turbine/dynamo/decompositions.py
@@ -47,7 +47,8 @@ def _extend_context_manager(
     *,
     from_current: bool = True,
     add_ops: Optional[DecompositionOpsList] = None,
-    remove_ops: Optional[DecompositionOpsList] = None
+    remove_ops: Optional[DecompositionOpsList] = None,
+    add_decomps: Optional[DecompositionTable] = None
 ):
     table: DecompositionTable
     if from_current:
@@ -58,6 +59,8 @@ def _extend_context_manager(
         table.update(get_decompositions(add_ops))
     if remove_ops:
         remove_decompositions(table, remove_ops)  # type: ignore
+    if add_decomps:
+        table.update(add_decomps)
     stack = _get_decomp_stack(scope)
     stack.append(table)
     try:


### PR DESCRIPTION
enables to pass a already populated table instead of list to turbine, requirement for torch 2.6 upgrade. Does not break anything from the existing mechanism